### PR TITLE
Fix interning when *print-case* is not :upcase.

### DIFF
--- a/esrap-liquid.asd
+++ b/esrap-liquid.asd
@@ -47,5 +47,5 @@
                (:file "tests")))
 
 (defmethod perform ((op test-op) (sys (eql (find-system :esrap-liquid))))
-  (load-system :esrap-tests)
+  (load-system :esrap-liquid-tests)
   (funcall (intern "RUN-TESTS" :esrap-liquid-tests)))

--- a/src/esrap-env.lisp
+++ b/src/esrap-env.lisp
@@ -39,7 +39,7 @@
 		     (defrule ,symbol ,args ,@body))))
 	  (defmacro ,(symbolicate "REGISTER-" symbol "-CONTEXT")
 	      (context-var &rest plausible-contexts)
-	    `(progn (defparameter ,context-var ,(make-keyword (format nil "~a" (car plausible-contexts))))
+	    `(progn (defparameter ,context-var ,(make-keyword (car plausible-contexts)))
 		    ,@(mapcar (lambda (context-name)
 				(let ((pred-name (symbolicate context-name
 								     "-"
@@ -57,7 +57,7 @@
 				       ;; will not work here anyway
 				       (pred #',pred-name t)
 				       nil))))
-			      (mapcar (lambda (x) (format nil "~a" x)) plausible-contexts))
+			      plausible-contexts)
 		    (push ',context-var ,',(symbolicate symbol "-CONTEXTS"))))
 	  (defmacro!! ,(symbolicate symbol "-PARSE")
 	      (expression text &key (start nil start-p)

--- a/tests/macro.lisp
+++ b/tests/macro.lisp
@@ -5,3 +5,8 @@
 
 (define-esrap-env foo)
 (define-esrap-env bar)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defparameter *old-print-case* *print-case*)
+  (setf *print-case* :downcase)
+  (register-foo-context foo-context-1 quux)
+  (setf *print-case* *old-print-case*))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -247,3 +247,9 @@
 
 (test start-of-file
   (is (equal "a" (parse '(progn esrap-liquid::sof "a") "a"))))
+
+;;; esrap-env
+
+(test esrap-env-print-case
+  (is (eq :quux foo-context-1))
+  (is-true (find-symbol "QUUX-FOO-CONTEXT-1-P")))


### PR DESCRIPTION
`format "~a"` converts symbol names to lower case when `*print-case*` is `:downcase`, and then `symbolicate` interns mixed case symbols.

This change allowed me to run `cl-yaclyaml:yaml-load-file` without error.